### PR TITLE
fix:修改技能监控排除GCD的写法，修复部分情况下技能CD监控不准确的问题

### DIFF
--- a/MY_!Base/src/lib/Game.Skill.lua
+++ b/MY_!Base/src/lib/Game.Skill.lua
@@ -445,7 +445,8 @@ function X.GetSkillCDProgress(KObject, dwID, nLevel, bIgnorePublic)
 	else -- 普通技能CD刷新
 		szType = 'NORMAL'
 		if bIgnorePublic then
-			nLeft, nTotal, nCount, bPublic = select(2, GetSkillCDProgress(dwID, nLevel, dwCDID, KObject))
+			local dwGCDID = KSkill.GetPublicCoolDown()
+			nLeft, nTotal, nCount, bPublic = select(2, GetSkillCDProgress(dwID, nLevel, dwGCDID, KObject))
 		else
 			nLeft, nTotal, nCount, bPublic = select(2, GetSkillCDProgress(dwID, nLevel, nil, KObject))
 		end


### PR DESCRIPTION
技能监控“风流云散”时CD不准确