### PR TITLE
fix: 焦点列表增加隐藏焦点方法

### DIFF
--- a/MY_Focus/src/MY_Focus.lua
+++ b/MY_Focus/src/MY_Focus.lua
@@ -882,7 +882,8 @@ function D.GetDisplayList()
 							end
 						end
 						if bRuleFocus then
-							bFocus = true
+							--2025.8.16增加隐藏焦点方法，上述规则满足后，判断最大距离是否为-1，若为-1不显示焦点并跳出规则遍历
+							if via.tRule.nMaxDistance == -1 then bFocus = false else bFocus = true end
 							tRule = via.tRule
 							szVia = via.szVia
 							bDeletable = via.bDeletable


### PR DESCRIPTION
焦点列表：增加隐藏焦点方法，当满足规则（血量百分比、目标关系）时，判断最大距离（nMaxDistance）是否为-1，若为-1则不显示焦点并跳出后续规则遍历。