### PR TITLE
feat: 修复正则场景下多段倒计时下标缺失

### DIFF
--- a/MY_TeamMon/src/MY_TeamMon.lua
+++ b/MY_TeamMon/src/MY_TeamMon.lua
@@ -1031,18 +1031,18 @@ function D.CountdownEvent(data, nClass, szSender, szReceiver, aBackreferences)
 					bTalk     = v.bTeamChannel,
 					bHold     = v.bHold,
 				}
-				D.FireCountdownEvent(nType, szKey, tParam, szSender, szReceiver)
+				D.FireCountdownEvent(nType, szKey, tParam, szSender, szReceiver, aBackreferences)
 			end
 		end
 	end
 end
 
 -- 发布事件 为了方便日后修改 集中起来
-function D.FireCountdownEvent(nType, szKey, tParam, szSender, szReceiver)
+function D.FireCountdownEvent(nType, szKey, tParam, szSender, szReceiver, aBackreferences)
 	if not O.bPushTeamChannel then
 		tParam.bTalk = false
 	end
-	FireUIEvent('MY_TEAM_MON__SPELL_TIMER__CREATE', nType, szKey, tParam, szSender, szReceiver)
+	FireUIEvent('MY_TEAM_MON__SPELL_TIMER__CREATE', nType, szKey, tParam, szSender, szReceiver, aBackreferences)
 end
 
 function D.GetSrcName(dwID)

--- a/MY_TeamMon/src/MY_TeamMon_SpellTimer.lua
+++ b/MY_TeamMon/src/MY_TeamMon_SpellTimer.lua
@@ -82,11 +82,11 @@ do
 end
 
 -- 解析分段倒计时
-local function ParseCountdown(szCountdown, szSender, szReceiver)
+local function ParseCountdown(szCountdown, szSender, szReceiver, aBackreferences)
 	local aCountdown = MY_TeamMon.ParseCountdown(szCountdown)
 	if X.IsTable(aCountdown) then
 		for _, v in ipairs(aCountdown) do
-			v.szContent = FilterCustomText(v.szContent, szSender, szReceiver)
+			v.szContent = FilterCustomText(v.szContent, szSender, szReceiver, aBackreferences)
 		end
 	end
 	return aCountdown
@@ -104,7 +104,7 @@ end
 -- }
 -- 例子：FireUIEvent('MY_TEAM_MON__SPELL_TIMER__CREATE', 0, 'test', { nTime = '5,test;15,测试;25,c', szName = 'demo' })
 -- 性能测试：for i = 1, 200 do FireUIEvent('MY_TEAM_MON__SPELL_TIMER__CREATE', 0, i, { nTime = Random(5, 15), nIcon = i }) end
-local function CreateCountdown(nType, szKey, tParam, szSender, szReceiver)
+local function CreateCountdown(nType, szKey, tParam, szSender, szReceiver, aBackreferences)
 	assert(type(tParam) == 'table', 'CreateCountdown failed!')
 	local tTime = {}
 	local nTime = GetTime()
@@ -114,7 +114,7 @@ local function CreateCountdown(nType, szKey, tParam, szSender, szReceiver)
 			szContent = tParam.szContent,
 		}
 	elseif X.IsString(tParam.nTime) then
-		local aCountdown = ParseCountdown(tParam.nTime, szSender, szReceiver)
+		local aCountdown = ParseCountdown(tParam.nTime, szSender, szReceiver, aBackreferences)
 		if aCountdown then
 			tTime = aCountdown[1]
 			tParam.nTime = aCountdown
@@ -177,7 +177,7 @@ end
 
 function D.OnEvent(szEvent)
 	if szEvent == 'MY_TEAM_MON__SPELL_TIMER__CREATE' then
-		CreateCountdown(arg0, arg1, arg2, arg3, arg4)
+		CreateCountdown(arg0, arg1, arg2, arg3, arg4, arg5)
 	elseif szEvent == 'MY_TEAM_MON__SPELL_TIMER__DEL' then
 		local ui = ST_CACHE[arg0][arg1]
 		if ui and ui:IsValid() then


### PR DESCRIPTION
在构建倒计时条时缺少传入aBackreferences参数，导致在分解多段倒计时条时未正确替换捕获文字