### PR TITLE
fix: 修复隐藏焦点逻辑判断问题

### DIFF
--- a/MY_Focus/src/MY_Focus.lua
+++ b/MY_Focus/src/MY_Focus.lua
@@ -851,7 +851,6 @@ function D.GetDisplayList()
 	local t = {}
 	local me = X.GetClientPlayer()
 	if not D.IsShielded() and me then
-		local tRemoveFocusList = {}
 		for _, p in ipairs(FOCUS_LIST) do
 			if #t >= O.nMaxDisplay then
 				break
@@ -871,7 +870,7 @@ function D.GetDisplayList()
 						and not X.JudgeOperator(via.tRule.tLife.szOperator, fCurrentLife / fMaxLife * 100, via.tRule.tLife.nValue) then
 							bRuleFocus = false
 						end
-						if bRuleFocus and via.tRule.nMaxDistance ~= 0
+						if bRuleFocus and via.tRule.nMaxDistance > 0
 						and X.GetCharacterDistance(me, KObject, O.szDistanceType) > via.tRule.nMaxDistance then
 							bRuleFocus = false
 						end
@@ -912,21 +911,8 @@ function D.GetDisplayList()
 						szVia = szVia,
 						bDeletable = bDeletable,
 					}, { __index = p }))
-				else
-					-- 不符合显示条件则记录到移除表
-					tRemoveFocusList[p.dwType .. '_' .. p.dwID] = true
 				end
 			end
-		end
-		-- 清理不符合显示条件的焦点并刷新事件
-		if next(tRemoveFocusList) then
-			for i = #FOCUS_LIST, 1, -1 do
-				local q = FOCUS_LIST[i]
-				if tRemoveFocusList[q.dwType .. '_' .. q.dwID] then
-					table.remove(FOCUS_LIST, i)
-				end
-			end
-			FireUIEvent('MY_FOCUS_UPDATE')
 		end
 	end
 	return t


### PR DESCRIPTION
当焦点符合隐藏条件时，实际客户端UI仍显示在在焦点列表内，因只标记bFocus为false，未真正删除FOCUS_LIST内的数据，现添加删除表移除符合隐藏条件的焦点对象，修复问题