### PR TITLE
fix: 陶罐助手暂停后无法清空积分缓存

### DIFF
--- a/!src-dist/changelog.py
+++ b/!src-dist/changelog.py
@@ -184,7 +184,7 @@ def process_changelog_input(changelog_input: str) -> List[str]:
         else:
             # 转换 插件:内容 或 插件：内容 格式为 * [插件] 内容
             if re.search(r"[：:]", line):
-                parts = re.split(r"[：:]", line, 1)
+                parts = re.split(r"[：:]", line, maxsplit=1)
                 plugin = parts[0].strip().strip('"').strip('"').strip('"')
                 content = (
                     parts[1].strip().strip('"').strip('"').strip('"')

--- a/MY_Toolbox/src/MY_Taoguan.lua
+++ b/MY_Toolbox/src/MY_Taoguan.lua
@@ -384,13 +384,12 @@ function D.MonitorZP(szChannel, szMsg)
 end
 
 function D.OnLootItem()
-	if not D.bEnable then
-		return
-	end
 	if arg0 == X.GetClientPlayer().dwID and arg2 > 2 and GetItem(arg1).szName == MEILIANGYUQIAN then
 		D.nPoint = 0
 		D.bWaitPoint = false
-		X.OutputSystemAnnounceMessage(_L['Auto taoguan: score clear!'])
+		if D.bEnable then
+			X.OutputSystemAnnounceMessage(_L['Auto taoguan: score clear!'])
+		end
 	end
 end
 


### PR DESCRIPTION
陶罐助手暂停后D.bEnable为关闭状态，若在此期间结算积分兑换梅玉良签，插件积分变量无法归零，导致额外使用道具